### PR TITLE
process: make `process.exitCode` configurable again

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -129,7 +129,7 @@ process.domain = null;
       exitCode = code;
     },
     enumerable: true,
-    configurable: false,
+    configurable: true,
   });
 }
 process._exiting = false;


### PR DESCRIPTION
This change was done in #44711, and it's not clear it was intentional. It caused #45683, and also makes it impossible to mock out the exitCode in tests.

Filing this PR per https://github.com/nodejs/node/pull/44711#discussion_r1320660607

Fixes #45683.